### PR TITLE
Use session to manage redirect location

### DIFF
--- a/odp/ui/base/__init__.py
+++ b/odp/ui/base/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import redis
-from flask import Flask
+from flask import Flask, session, request
 from jinja2 import ChoiceLoader, FileSystemLoader
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -97,3 +97,8 @@ def init_app(
 
     # trust the X-Forwarded-* headers set by the proxy server
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_prefix=1)
+
+    @app.context_processor
+    def set_active_url():
+        session['active_page_url'] = request.url
+        return dict()

--- a/odp/ui/client.py
+++ b/odp/ui/client.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import requests
 from authlib.integrations.flask_client import OAuth
-from flask import Flask, Response, flash, g, redirect, request, url_for
+from flask import Flask, Response, flash, g, redirect, request, url_for, session
 from flask_login import LoginManager, current_user, login_user, logout_user
 from redis import Redis
 
@@ -190,7 +190,9 @@ class ODPUserClient(ODPBaseClient):
 
         login_user(localuser)
 
-        return redirect(url_for('home.index'))
+        active_page = session.get('active_page_url') or url_for('home.index')
+
+        return redirect(active_page)
 
     def _logout(self):
         """Initiate logout.


### PR DESCRIPTION
- Added a context_processor to the flask app to keep track of the "active_page_url" using the session.
- When returning from identity service, use the "active_page_url" session variable to redirect back to the active page.