### PR TITLE
Allow enter to submit filter form when focused on map

### DIFF
--- a/odp/ui/base/static/scripts/catalog.js
+++ b/odp/ui/base/static/scripts/catalog.js
@@ -26,6 +26,18 @@ function _initMap(n, e, s, w) {
         imperial: false
     }).addTo(map);
 
+    const mapContainer = map.getContainer();
+    mapContainer.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            setFilter();
+            const form = mapContainer.closest('form');
+            if (form) {
+                form.submit();
+            }
+        }
+    });
+
     return map;
 }
 


### PR DESCRIPTION
When focus is on the map and the user presses the enter key, the event will be picked up and will submit the form with the selected geographical extent.