### PR TITLE
Client-side ZIP download via JSZip popup

### DIFF
--- a/odp/ui/base/macros/catalog.j2
+++ b/odp/ui/base/macros/catalog.j2
@@ -11,7 +11,7 @@
                     <h5 class="modal-title" id="downloadModalLabel">Download Confirmation</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <form id="download-audit-form" method="post" action="{{ url_for('catalog.download_audit') }}">
+                <form id="download-audit-form" method="post">
                     <div class="modal-body">
                         <p>Please provide some information before downloading.</p>
                         {{ form.csrf_token }}

--- a/odp/ui/base/macros/lib.j2
+++ b/odp/ui/base/macros/lib.j2
@@ -43,3 +43,8 @@
 {% macro chartjs_js() %}
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
 {% endmacro %}
+
+{% macro jszip_js() %}
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"
+            crossorigin="anonymous"></script>
+{% endmacro %}

--- a/odp/ui/base/static/scripts/catalog.js
+++ b/odp/ui/base/static/scripts/catalog.js
@@ -375,20 +375,34 @@ function initDownloadModal() {
     }
 
     if (downloadAuditForm) {
-        downloadAuditForm.addEventListener('submit', function () {
-            // Show loader and disable button while server generates ZIP
-            const loader = submitDownloadBtn?.querySelector('.submit-download-loader');
-            if (loader) loader.style.display = 'inline-block';
-            if (submitDownloadBtn) submitDownloadBtn.disabled = true;
+        downloadAuditForm.addEventListener('submit', function (e) {
+            e.preventDefault();
 
-            saveDownloadCache(
-                document.getElementById('download-name').value,
-                document.getElementById('download-email').value,
-                document.getElementById('organisation').value
+            const name         = document.getElementById('download-name').value;
+            const email        = document.getElementById('download-email').value;
+            const organisation = document.getElementById('organisation').value;
+            saveDownloadCache(name, email, organisation);
+
+            const recordIds = [...downloadAuditForm.querySelectorAll('input[name="record_ids"]')]
+                .map(i => i.value);
+
+            localStorage.setItem('odp-download-request', JSON.stringify({
+                recordIds,
+                userData: {name, email, organisation},
+            }));
+
+            const popup = window.open(
+                rootPath + '/catalog/download-progress',
+                'odp-download',
+                'width=520,height=200,resizable=yes,scrollbars=no'
             );
 
-            // Close modal after a short delay — download proceeds in browser's download bar
-            setTimeout(() => downloadModalInstance.hide(), 1500);
+            downloadModalInstance.hide();
+
+            if (!popup) {
+                localStorage.removeItem('odp-download-request');
+                showNotification('Please allow popups for this site to enable downloads, then try again.', 'warning');
+            }
         });
     }
 }

--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -1,0 +1,89 @@
+const bar = document.getElementById('download-bar');
+const statusEl = document.getElementById('download-status');
+const detailEl = document.getElementById('download-detail');
+const pctEl = document.getElementById('download-pct');
+const spinner = document.getElementById('status-spinner');
+
+function setProgress(pct, label, detail) {
+    const p = Math.round(pct);
+    if (bar) { bar.style.width = p + '%'; bar.setAttribute('aria-valuenow', p); }
+    if (pctEl) pctEl.textContent = p + '%';
+    if (statusEl) statusEl.textContent = label;
+    if (detailEl && detail !== undefined) detailEl.textContent = detail;
+}
+
+async function runDownload() {
+    const req = JSON.parse(localStorage.getItem('odp-download-request') || 'null');
+    if (!req) {
+        setProgress(0, 'No download request found.', 'Close this tab and try again.');
+        if (spinner) spinner.style.display = 'none';
+        return;
+    }
+    localStorage.removeItem('odp-download-request');
+
+    const { recordIds, userData } = req;
+
+    try {
+        setProgress(0, 'Preparing download…', '');
+        const response = await fetch(rootPath + '/catalog/download-bundle', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ record_ids: recordIds, user_data: userData }),
+        });
+        if (!response.ok) throw new Error(`Server error: ${response.status}`);
+        const data = await response.json();
+
+        const zip = new JSZip();
+        const fileRange = 65;
+        for (let i = 0; i < data.records.length; i++) {
+            const rec = data.records[i];
+            const folder = zip.folder(rec.folder_name);
+            folder.file('Metadata.pdf', rec.metadata_pdf, { base64: true });
+
+            setProgress(
+                15 + fileRange * i / data.records.length,
+                `Downloading file ${i + 1} of ${data.records.length}…`,
+                rec.data_file_name || ''
+            );
+
+            if (rec.data_file_url) {
+                let fileRes = null;
+                try { fileRes = await fetch(rec.data_file_url + '/download'); } catch (_) { }
+                if (!fileRes || !fileRes.ok) {
+                    fileRes = await fetch(
+                        rootPath + '/catalog/proxy-download?url=' + encodeURIComponent(rec.data_file_url)
+                    );
+                }
+                if (fileRes && fileRes.ok) {
+                    folder.file(rec.data_file_name, await fileRes.arrayBuffer());
+                }
+            }
+        }
+
+        const blob = await zip.generateAsync(
+            { type: 'blob', compression: 'STORE' },
+            ({ percent }) => setProgress(80 + percent * 0.2, 'Assembling ZIP…', Math.round(percent) + '%')
+        );
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = 'records.zip';
+        document.body.appendChild(a); a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        if (bar) { bar.classList.remove('progress-bar-striped', 'progress-bar-animated'); bar.classList.add('bg-success'); }
+        if (spinner) spinner.style.display = 'none';
+        setProgress(100, '✓ Download complete!', 'You can close this tab.');
+        if (pctEl) pctEl.textContent = '';
+
+    } catch (err) {
+        console.error('Download failed:', err);
+        if (bar) { bar.classList.remove('progress-bar-striped', 'progress-bar-animated'); bar.classList.add('bg-danger'); }
+        if (spinner) spinner.style.display = 'none';
+        setProgress(0, '✗ Download failed.', 'Close this tab and try again.');
+        if (pctEl) pctEl.textContent = '';
+    }
+}
+
+window.addEventListener('load', runDownload);

--- a/odp/ui/base/templates/download_progress.html
+++ b/odp/ui/base/templates/download_progress.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+{% from 'lib.j2' import bootswatch_spacelab_css, jszip_js %}
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Downloading…</title>
+    {{ bootswatch_spacelab_css() }}
+    <style>
+        body {
+            padding: 1.5rem;
+            background: #f8f9fa;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="d-flex align-items-center mb-3 gap-2">
+                <div id="status-spinner" class="spinner-border spinner-border-sm text-primary flex-shrink-0"
+                    role="status" aria-hidden="true"></div>
+                <span id="download-status" class="fw-semibold">Preparing download…</span>
+            </div>
+            <div class="progress mb-2" style="height: 8px;">
+                <div id="download-bar" class="progress-bar progress-bar-striped progress-bar-animated"
+                    role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <div class="d-flex justify-content-between">
+                <small id="download-detail" class="text-muted"></small>
+                <small id="download-pct" class="text-muted">0%</small>
+            </div>
+            <p class="text-muted mt-3 mb-0" style="font-size: 0.78rem;">
+                <strong>Note:</strong> Some files may be large and take a few minutes.
+                Do not close this window — you can minimise it and continue using the application.
+            </p>
+        </div>
+    </div>
+
+    {{ jszip_js() }}
+    <script>
+        const rootPath = {{ request.script_root | tojson }};
+    </script>
+    <script src="{{ url_for('static', filename='scripts/download_progress.js') }}"></script>
+</body>
+
+</html>

--- a/odp/ui/base/views/catalog.py
+++ b/odp/ui/base/views/catalog.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
 from random import randint
-from typing import Optional
-
-from flask import Blueprint, abort, current_app, flash, make_response, redirect, render_template, request, stream_with_context, url_for, Response
+import requests as http_requests
+from flask import Blueprint, abort, current_app, flash, jsonify, make_response, redirect, render_template, request, stream_with_context, url_for, Response
 
 from odp.const import ODPMetadataSchema
 from odp.lib.client import ODPAPIError
@@ -40,7 +39,7 @@ def doi_title(doi: str) -> str:
     return ''
 
 
-def _select_metadata(record: dict, schema_id: ODPMetadataSchema) -> Optional[dict]:
+def _select_metadata(record: dict, schema_id: ODPMetadataSchema) -> dict | None:
     return next(
         (metadata_record['metadata']
          for metadata_record in record['metadata_records']
@@ -56,19 +55,19 @@ def select_datacite_metadata(record: dict) -> dict:
 
 
 @bp.app_template_filter()
-def select_iso19115_metadata(record: dict) -> Optional[dict]:
+def select_iso19115_metadata(record: dict) -> dict | None:
     """Select the ISO19115 metadata dict, if present."""
     return _select_metadata(record, ODPMetadataSchema.SAEON_ISO19115)
 
 
 @bp.app_template_filter()
-def select_schemaorg_metadata(record: dict) -> Optional[dict]:
+def select_schemaorg_metadata(record: dict) -> dict | None:
     """Select the schema.org (JSON-LD) metadata dict, if present."""
     return _select_metadata(record, ODPMetadataSchema.SCHEMAORG_DATASET)
 
 
 @bp.app_template_filter()
-def select_ris_metadata(record: dict) -> Optional[dict]:
+def select_ris_metadata(record: dict) -> dict | None:
     """Select the RIS metadata dict, if present."""
     return _select_metadata(record, ODPMetadataSchema.RIS_CITATION)
 
@@ -251,49 +250,65 @@ def subset_record_list():
         facet_values={},
     )
 
-@bp.route('/download-audit', methods=['POST'])
-def download_audit():
+@bp.route('/download-bundle', methods=['POST'])
+def download_bundle():
     """
-    Validates the download audit form with WTForms, then forwards the request
-    to the ODP API server for ZIP bundle generation and returns the file.
+    Accepts JSON from the browser fetch(). Validates user fields, forwards to
+    /catalog/metadata-bundle on the API server, returns JSON to the browser.
     """
-    form = DownloadAuditForm(request.form)
-    record_ids = request.form.getlist('record_ids')
+    data = request.get_json(silent=True) or {}
+    user_data = data.get('user_data', {})
 
-    if not form.validate() or not record_ids:
-        flash('Please fill in all required fields before downloading.')
-        return redirect(request.referrer or url_for('catalog.index'))
+    if not all(user_data.get(f) for f in ('name', 'email', 'organisation')):
+        return jsonify({'error': 'name, email and organisation are required'}), 400
+
+    record_ids = data.get('record_ids', [])
+    if not record_ids:
+        return jsonify({'error': 'No records selected'}), 400
 
     payload = {
         'record_ids': record_ids,
-        'user_data': {
-            'name': form.name.data,
-            'email': form.email.data,
-            'organisation': form.organisation.data,
-        }
+        'user_data': user_data,
+        'client_ip': request.remote_addr,
+        'user_agent': request.headers.get('User-Agent'),
+        'referer': request.referrer,
     }
 
     try:
-        api_response = cli.stream_post('/catalog/generate-zip-bundle', payload)
-        
+        result = cli.post('/catalog/metadata-bundle', payload)
+        return jsonify(result)
+    except Exception as e:
+        current_app.logger.error(f"Metadata bundle request failed: {e}", exc_info=True)
+        return jsonify({'error': 'Failed to generate metadata bundle'}), 500
+
+
+@bp.route('/proxy-download')
+def proxy_download():
+    """
+    Proxies a data file from external storage to the browser.
+    Used as a CORS fallback when the browser cannot fetch directly.
+    Only allows URLs from repository.ocean.gov.za.
+    """
+    url = request.args.get('url', '')
+    if not url.startswith('https://repository.ocean.gov.za/'):
+        return jsonify({'error': 'URL not allowed'}), 403
+
+    try:
+        upstream = http_requests.get(url + '/download', stream=True, timeout=60)
+        upstream.raise_for_status()
+        content_type = upstream.headers.get('Content-Type', 'application/octet-stream')
+
         def generate():
-            for chunk in api_response.iter_content(chunk_size=8192):
+            for chunk in upstream.iter_content(chunk_size=8192):
                 if chunk:
                     yield chunk
 
-        headers = {
-            'Content-Disposition': 'attachment; filename="records.zip"',
-        }
-        if 'Content-Length' in api_response.headers:
-            headers['Content-Length'] = api_response.headers['Content-Length']
-
-        return Response(
-            stream_with_context(generate()),
-            mimetype='application/zip',
-            headers=headers
-        )
-
+        return Response(stream_with_context(generate()), content_type=content_type)
     except Exception as e:
-        current_app.logger.error(f"ZIP generation failed: {str(e)}", exc_info=True)
-        flash('Failed to generate ZIP bundle. Please try again.')
-        return redirect(request.referrer or url_for('catalog.index'))
+        current_app.logger.error(f"Proxy download failed for {url}: {e}")
+        return jsonify({'error': 'Proxy download failed'}), 502
+
+
+@bp.route('/download-progress')
+def download_progress():
+    return render_template('download_progress.html')


### PR DESCRIPTION
Replace server-side ZIP streaming with browser-assembled ZIP:
- Remove download_audit Flask route (called dead generate-zip-bundle endpoint)
- Add download_bundle, proxy_download, download_progress Flask routes
- Popup window reads localStorage request, fetches metadata bundle from server, downloads data files directly from external storage, assembles ZIP via JSZip
- Extract popup JS to download_progress.js; template uses lib.j2 macros
- Remove dead form action from download_audit_modal; restore jszip_js macro