### PR TITLE
Fix missing file extension for data files with no URL extension

### DIFF
--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -55,7 +55,14 @@ async function runDownload() {
                     );
                 }
                 if (fileRes && fileRes.ok) {
-                    folder.file(rec.data_file_name, await fileRes.arrayBuffer());
+                    let fileName = rec.data_file_name;
+                    const cd = fileRes.headers.get('content-disposition');
+                    if (cd) {
+                        const m = cd.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i);
+                        if (m) fileName = decodeURIComponent(m[1].replace(/['"]/g, '').trim());
+                    }
+                    if (fileName && !/\.\w+$/.test(fileName)) fileName += '.zip';
+                    folder.file(fileName, await fileRes.arrayBuffer());
                 }
             }
         }

--- a/odp/ui/base/views/catalog.py
+++ b/odp/ui/base/views/catalog.py
@@ -297,13 +297,17 @@ def proxy_download():
         upstream = http_requests.get(url + '/download', stream=True, timeout=60)
         upstream.raise_for_status()
         content_type = upstream.headers.get('Content-Type', 'application/octet-stream')
+        content_disposition = upstream.headers.get('Content-Disposition', '')
 
         def generate():
             for chunk in upstream.iter_content(chunk_size=8192):
                 if chunk:
                     yield chunk
 
-        return Response(stream_with_context(generate()), content_type=content_type)
+        resp = Response(stream_with_context(generate()), content_type=content_type)
+        if content_disposition:
+            resp.headers['Content-Disposition'] = content_disposition
+        return resp
     except Exception as e:
         current_app.logger.error(f"Proxy download failed for {url}: {e}")
         return jsonify({'error': 'Proxy download failed'}), 502


### PR DESCRIPTION
Read Content-Disposition from the download response to get the real filename; fall back to appending .zip when the name still has no extension. Also forward Content-Disposition through the proxy route so the fallback path provides the same header.