### PR TITLE
Add download form validation; revert PR #19 Content-Disposition parsing

### DIFF
--- a/odp/ui/base/static/scripts/catalog.js
+++ b/odp/ui/base/static/scripts/catalog.js
@@ -378,9 +378,43 @@ function initDownloadModal() {
         downloadAuditForm.addEventListener('submit', function (e) {
             e.preventDefault();
 
-            const name         = document.getElementById('download-name').value;
-            const email        = document.getElementById('download-email').value;
-            const organisation = document.getElementById('organisation').value;
+            const nameField  = document.getElementById('download-name');
+            const emailField = document.getElementById('download-email');
+            const orgField   = document.getElementById('organisation');
+
+            const name         = nameField.value.trim();
+            const email        = emailField.value.trim();
+            const organisation = orgField.value.trim();
+
+            // Reset previous validation state
+            [nameField, emailField, orgField].forEach(f => f.classList.remove('is-invalid'));
+            document.getElementById('error-name').textContent = '';
+            document.getElementById('error-email').textContent = '';
+            document.getElementById('error-organisation').textContent = '';
+
+            let valid = true;
+            if (!name) {
+                nameField.classList.add('is-invalid');
+                document.getElementById('error-name').textContent = 'Name is required.';
+                valid = false;
+            }
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!email) {
+                emailField.classList.add('is-invalid');
+                document.getElementById('error-email').textContent = 'Email is required.';
+                valid = false;
+            } else if (!emailRegex.test(email)) {
+                emailField.classList.add('is-invalid');
+                document.getElementById('error-email').textContent = 'Please enter a valid email address.';
+                valid = false;
+            }
+            if (!organisation) {
+                orgField.classList.add('is-invalid');
+                document.getElementById('error-organisation').textContent = 'Organisation is required.';
+                valid = false;
+            }
+            if (!valid) return;
+
             saveDownloadCache(name, email, organisation);
 
             const recordIds = [...downloadAuditForm.querySelectorAll('input[name="record_ids"]')]

--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -50,18 +50,12 @@ async function runDownload() {
                 let fileRes = null;
                 try { fileRes = await fetch(rec.data_file_url + '/download'); } catch (_) { }
                 if (!fileRes || !fileRes.ok) {
-                    try {
-                        fileRes = await fetch(
-                            rootPath + '/catalog/proxy-download?url=' + encodeURIComponent(rec.data_file_url)
-                        );
-                    } catch (_) { }
+                    fileRes = await fetch(
+                        rootPath + '/catalog/proxy-download?url=' + encodeURIComponent(rec.data_file_url)
+                    );
                 }
                 if (fileRes && fileRes.ok) {
                     folder.file(rec.data_file_name, await fileRes.arrayBuffer());
-                } else {
-                    folder.file('data_file_unavailable.txt',
-                        `The data file could not be downloaded.\n\nURL: ${rec.data_file_url}\n\nPlease try downloading it directly from the catalog record page.`
-                    );
                 }
             }
         }

--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -55,14 +55,7 @@ async function runDownload() {
                     );
                 }
                 if (fileRes && fileRes.ok) {
-                    let fileName = rec.data_file_name;
-                    const cd = fileRes.headers.get('content-disposition');
-                    if (cd) {
-                        const m = cd.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i);
-                        if (m) fileName = decodeURIComponent(m[1].replace(/['"]/g, '').trim());
-                    }
-                    if (fileName && !/\.\w+$/.test(fileName)) fileName += '.zip';
-                    folder.file(fileName, await fileRes.arrayBuffer());
+                    folder.file(rec.data_file_name, await fileRes.arrayBuffer());
                 }
             }
         }

--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -50,12 +50,18 @@ async function runDownload() {
                 let fileRes = null;
                 try { fileRes = await fetch(rec.data_file_url + '/download'); } catch (_) { }
                 if (!fileRes || !fileRes.ok) {
-                    fileRes = await fetch(
-                        rootPath + '/catalog/proxy-download?url=' + encodeURIComponent(rec.data_file_url)
-                    );
+                    try {
+                        fileRes = await fetch(
+                            rootPath + '/catalog/proxy-download?url=' + encodeURIComponent(rec.data_file_url)
+                        );
+                    } catch (_) { }
                 }
                 if (fileRes && fileRes.ok) {
                     folder.file(rec.data_file_name, await fileRes.arrayBuffer());
+                } else {
+                    folder.file('data_file_unavailable.txt',
+                        `The data file could not be downloaded.\n\nURL: ${rec.data_file_url}\n\nPlease try downloading it directly from the catalog record page.`
+                    );
                 }
             }
         }

--- a/odp/ui/base/views/catalog.py
+++ b/odp/ui/base/views/catalog.py
@@ -297,17 +297,13 @@ def proxy_download():
         upstream = http_requests.get(url + '/download', stream=True, timeout=60)
         upstream.raise_for_status()
         content_type = upstream.headers.get('Content-Type', 'application/octet-stream')
-        content_disposition = upstream.headers.get('Content-Disposition', '')
 
         def generate():
             for chunk in upstream.iter_content(chunk_size=8192):
                 if chunk:
                     yield chunk
 
-        resp = Response(stream_with_context(generate()), content_type=content_type)
-        if content_disposition:
-            resp.headers['Content-Disposition'] = content_disposition
-        return resp
+        return Response(stream_with_context(generate()), content_type=content_type)
     except Exception as e:
         current_app.logger.error(f"Proxy download failed for {url}: {e}")
         return jsonify({'error': 'Proxy download failed'}), 502


### PR DESCRIPTION
Added client-side validation for name, email, and organisation before the download popup opens. The HTML5 validation was being bypassed because the form submit handler calls e.preventDefault() first. PR #19 had added Content-Disposition header parsing in download_progress.js to extract the real filename from the download response, but this caused a silent failure where the assembled ZIP contained only Metadata.pdf with the data file missing. Both the client-side parsing and the proxy-route header forwarding added in PR #19 have been reverted. File extension handling is done server-side by _ensure_extension() in odp-server.