### PR TITLE
Refactor(UI): Remove redundant download_link.txt from ZIP generator

### DIFF
--- a/odp/ui/base/static/scripts/download_progress.js
+++ b/odp/ui/base/static/scripts/download_progress.js
@@ -53,8 +53,6 @@ async function runDownload() {
             );
 
             if (rec.data_file_url) {
-                folder.file('download_link.txt', rec.data_file_url);
-
                 let fileRes = null;
                 try { fileRes = await fetch(rec.data_file_url + '/download'); } catch (_) { }
                 if (!fileRes || !fileRes.ok) {


### PR DESCRIPTION
Removed the creation of the fallback download_link.txt file from the client-side ZIP bundler, as the actual data files are either already being fetched successfully or are no longer required in the bundle.